### PR TITLE
feat(db): add Flask+SQLAlchemy setup, psycopg3 driver, routes and template; requirements.txt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,41 @@
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.pyc
+
+# Environments
+venv/
+.env
+.venv
+env/
+
+# OS
+.DS_Store
+
+# IDE
+.idea/
+.vscode/
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+*.pyc
+
+# Environments
+venv/
+.env
+.venv
+env/
+
+# OS
+.DS_Store
+
+# IDE
+.idea/
+.vscode/
+
+

--- a/app.py
+++ b/app.py
@@ -1,0 +1,20 @@
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+from config import Config
+
+
+app = Flask(__name__)
+app.config.from_object(Config)
+db = SQLAlchemy(app)
+
+
+from routes import *  # noqa: E402,F401
+
+
+if __name__ == '__main__':
+    # Create tables automatically on startup
+    with app.app_context():
+        db.create_all()
+    app.run(debug=True)
+
+

--- a/config.py
+++ b/config.py
@@ -1,0 +1,17 @@
+import os
+
+
+def _normalize_database_url(url: str) -> str:
+    # Ensure psycopg3 driver is used if scheme is plain postgresql
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg://", 1)
+    return url
+
+
+class Config:
+    _default_url = "postgresql+psycopg://username:password@localhost/mi_flask_app"
+    SQLALCHEMY_DATABASE_URI = _normalize_database_url(os.environ.get("DATABASE_URL", _default_url))
+    SQLALCHEMY_TRACK_MODIFICATIONS = False
+    SECRET_KEY = os.environ.get("SECRET_KEY", "tu_clave_secreta_aqui")
+
+

--- a/models.py
+++ b/models.py
@@ -1,0 +1,13 @@
+from app import db
+
+
+class Usuario(db.Model):
+    __tablename__ = 'usuarios'
+    id = db.Column(db.Integer, primary_key=True)
+    nombre = db.Column(db.String(50), nullable=False)
+    email = db.Column(db.String(120), unique=True, nullable=False)
+
+    def __repr__(self) -> str:
+        return f'<Usuario {self.nombre}>'
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+Flask==3.1.2
+Flask-SQLAlchemy==3.1.1
+SQLAlchemy==2.0.43
+psycopg-binary==3.2.9
+
+

--- a/routes.py
+++ b/routes.py
@@ -1,0 +1,19 @@
+from app import app, db
+from models import Usuario
+from flask import render_template, redirect, url_for
+
+
+@app.route('/add_user/<nombre>/<email>')
+def add_user(nombre: str, email: str):
+    usuario = Usuario(nombre=nombre, email=email)
+    db.session.add(usuario)
+    db.session.commit()
+    return redirect(url_for('usuarios'))
+
+
+@app.route('/usuarios')
+def usuarios():
+    usuarios = Usuario.query.all()
+    return render_template('usuarios.html', usuarios=usuarios)
+
+

--- a/templates/usuarios.html
+++ b/templates/usuarios.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Lista de Usuarios</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
+    <h1>Usuarios</h1>
+    <ul>
+        {% for usuario in usuarios %}
+        <li>{{ usuario.nombre }} - {{ usuario.email }}</li>
+        {% endfor %}
+    </ul>
+    <p><a href="/add_user/Nombre/usuario@example.com">Agregar de prueba</a></p>
+    <p><a href="/usuarios">Refrescar lista</a></p>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces a basic Flask application with SQLAlchemy integration and a simple user management feature. The main changes include setting up the application and database configuration, defining a user model, creating routes for adding and listing users, and providing a template to display the user list.

**Application and Database Setup:**

* Added `app.py` to initialize the Flask app, configure it using the `Config` class, and set up SQLAlchemy. The database tables are automatically created on startup.
* Added `config.py` to handle environment-based configuration, including normalization of the database URL for the correct PostgreSQL driver and setting secret keys.

**User Management Feature:**

* Added `models.py` with a `Usuario` model representing users, including fields for name and email, and a custom string representation.
* Added `routes.py` with endpoints to add a new user (`/add_user/<nombre>/<email>`) and to display all users (`/usuarios`). The add route commits new users to the database and redirects to the user list.
* Added a template `usuarios.html` to render the list of users and provide links to add a sample user and refresh the list.